### PR TITLE
Issue #16: Sanitized embedded errstr for handle_errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Unreleased
 ----------
 - Added formatted message string to on_error parameters
 - Renamed project to 'py-buzz'
+- Added error sanitization for messages with embedded curly braces
 
 v0.1.7 - 2016-12-22
 -------------------

--- a/buzz/__init__.py
+++ b/buzz/__init__.py
@@ -76,6 +76,7 @@ class Buzz(Exception):
         except Exception as err:
             final_message = message.format(*format_args, **format_kwds)
             final_message = "{} -- Error: {}".format(final_message, str(err))
+            final_message = cls.sanitize_errstr(final_message)
             if on_error is not None:
                 on_error(err, final_message)
             raise cls(final_message)

--- a/tests/test_buzz.py
+++ b/tests/test_buzz.py
@@ -88,3 +88,16 @@ class TestBuzz:
         assert '`checker += 1 == 2` resolved as false' in err_msg
         assert '`checker += \'cooooooool\' resolved as false' not in err_msg
         assert '`checker += 0` resolved as false' in err_msg
+
+    def test_nested_handler(self):
+        """
+        This test verifies that a handler that is nested inside another buzz
+        catching mechanism properly sanitizes the final error string so that
+        format arguments in the outside mechanism don't get caught up in
+        curly braces in the final error string
+        """
+        with pytest.raises(Buzz) as err_info:
+            with Buzz.handle_errors("outside handler"):
+                with Buzz.handle_errors("inside handler"):
+                    raise Exception("this has {curlies}")
+        assert 'this has {curlies}' in err_info.value.message


### PR DESCRIPTION
This should ensure that any handlers upstream of the handle_errors
mechanism shouldn't get frustrated with trying to apply formatting args
to curly literals inside the error string